### PR TITLE
Instructions for using Vagrant on OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ sh install_requirements.sh
 The Coral USB Accelerator is not supported under OSX, but you can use it from
 a Linux VM under VirtualBox if you forward the USB port through.
 
-```
+```bash
 # virtualbox will prompt you to enable it in security settings.
 # Re-run the install if this causes it to error out the first time.
 brew cask install virtualbox
@@ -107,10 +107,38 @@ vagrant plugin install vagrant-vbguest
 
 Once you have installed the requirements, you can start the machine.
 This will take a while.
-```
+```bash
 vagrant up
+# Reboot it with the correct version of guest additions installed.
+vagrant reload
 ```
 
+Once everything is built, you can get a shell by typing:
+```bash
+vagrant ssh
+```
+
+Now that you're in, you should check that the coral device is visible:
+```
+$ lsusb
+Bus 002 Device 003: ID 1a6e:089a Global Unichip Corp. 
+Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+```
+
+You can run the examples as described below, from the project-posenet dir
+```bash
+cd project-posenet
+python3 simple_pose.py
+```
+
+Once you have run an example, the device's id will change:
+```
+$ lsusb
+Bus 002 Device 002: ID 18d1:9302 Google Inc. 
+Bus 002 Device 001: ID 1d6b:0003 Linux Foundation 3.0 root hub
+Bus 001 Device 001: ID 1d6b:0002 Linux Foundation 2.0 root hub
+```
 
 ## Examples in this repo
 

--- a/README.md
+++ b/README.md
@@ -76,18 +76,43 @@ a keypoint has been detected.
 
 
 
-## Examples in this repo
+## Setup
 
 NOTE: PoseNet relies on the latest Coral API (2.11.1) - please update your
 system before running these examples. For more information on updating see:
   * For [Coral DevBoard](https://coral.withgoogle.com/docs/dev-board/get-started/#update-the-mendel-software)
   * For [USB Accelerator](https://coral.withgoogle.com/docs/accelerator/get-started/#set-up-on-linux-or-raspberry-pi)
 
+### Linux
+
 To install all the requirements, simply run 
 
 ```
 sh install_requirements.sh
 ```
+
+### OSX
+
+The Coral USB Accelerator is not supported under OSX, but you can use it from
+a Linux VM under VirtualBox if you forward the USB port through.
+
+```
+# virtualbox will prompt you to enable it in security settings.
+# Re-run the install if this causes it to error out the first time.
+brew cask install virtualbox
+brew cask install vagrant
+brew cask install virtualbox-extension-pack
+vagrant plugin install vagrant-vbguest
+```
+
+Once you have installed the requirements, you can start the machine.
+This will take a while.
+```
+vagrant up
+```
+
+
+## Examples in this repo
 
 ### simple_pose.py
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -67,6 +67,10 @@ Vagrant.configure("2") do |config|
     # As a work-around, run the whole thing as root :-(
     yes | sudo edgetpu_api/install.sh
   SHELL
+
+  # When we're done with the generic setup, do the specific setup as well:
+  config.vm.provision "shell", path: 'install_requirements.sh'
+
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
   # `vagrant box outdated`. This is not recommended.

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -96,5 +96,5 @@ Vagrant.configure("2") do |config|
   # the path on the host to the actual folder. The second argument is
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
-  # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/home/vagrant/project-posenet"
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -12,8 +12,61 @@ Vagrant.configure("2") do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://vagrantcloud.com/search.
-  config.vm.box = "ubuntu/bionic"
+  config.vm.box = "generic/ubuntu1804"
 
+  # Booting takes 5-10 minutes for ubuntu official boxes, but the `generic`
+  # ones are much faster. I'll leave this as 10 minutes in case anyone wants
+  # to switch to a different config.vm.box later.
+  config.vm.boot_timeout = 600
+
+  config.vm.provider "virtualbox" do |vb|
+    # This requires `brew cask install virtualbox-extension-pack` for USB3
+    vb.customize ["modifyvm", :id, "--usbxhci", "on"]
+
+    # There doesn't seem to be a way to idempotently add a rule, and any command
+    # that fails will abort vm startup, so there's no way for me to clean up
+    # old rules reliably either.
+    # This means that you will get duplicate rules with the same name piling up
+    # in the ui, but you'll only notice them if you go looking. I'm very sorry.
+
+    # This is the first device that shows up on the bus.
+    vb.customize [
+      'usbfilter', 'add', '0',
+        '--target', :id,
+        '--name', 'Coral USB Accelerator',
+        '--vendorid', '0x1a6e',
+        '--productid', '0x089a',
+    ]
+    # This is the second device that shows up when you actually try to use the
+    # thing from a python script.
+    # See https://dev.to/kojikanao/coral-edgetpu-usb-with-virtualbox-57e1 for
+    # details.
+    vb.customize [
+      'usbfilter', 'add', '0',
+        '--target', :id,
+        '--name', 'Google Inc. Coral USB Accelerator',
+        '--vendorid', '0x18d1',
+        '--productid', '0x9302',
+    ]
+
+    # # Customize the amount of memory on the VM:
+    # vb.memory = "1024"
+  end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    # lsusb is useful for debugging the coral usb forwarding:
+    apt install -y usbutils
+    # from https://coral.withgoogle.com/docs/accelerator/get-started/
+    wget https://dl.google.com/coral/edgetpu_api/edgetpu_api_latest.tar.gz \
+        -O edgetpu_api.tar.gz --trust-server-names
+    tar xzf edgetpu_api.tar.gz
+    # TODO: there is a line in the script that says:
+    #     sudo udevadm control --reload-rules && udevadm trigger
+    # when it should say:
+    #     sudo udevadm control --reload-rules && sudo udevadm trigger
+    # As a work-around, run the whole thing as root :-(
+    yes | sudo edgetpu_api/install.sh
+  SHELL
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
   # `vagrant box outdated`. This is not recommended.
@@ -44,27 +97,4 @@ Vagrant.configure("2") do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
-
-  # Provider-specific configuration so you can fine-tune various
-  # backing providers for Vagrant. These expose provider-specific options.
-  # Example for VirtualBox:
-  #
-  # config.vm.provider "virtualbox" do |vb|
-  #   # Display the VirtualBox GUI when booting the machine
-  #   vb.gui = true
-  #
-  #   # Customize the amount of memory on the VM:
-  #   vb.memory = "1024"
-  # end
-  #
-  # View the documentation for the provider you are using for more
-  # information on available options.
-
-  # Enable provisioning with a shell script. Additional provisioners such as
-  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
-  # documentation for more information about their specific syntax and use.
-  # config.vm.provision "shell", inline: <<-SHELL
-  #   apt-get update
-  #   apt-get install -y apache2
-  # SHELL
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,70 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# All Vagrant configuration is done below. The "2" in Vagrant.configure
+# configures the configuration version (we support older styles for
+# backwards compatibility). Please don't change it unless you know what
+# you're doing.
+Vagrant.configure("2") do |config|
+  # The most common configuration options are documented and commented below.
+  # For a complete reference, please see the online documentation at
+  # https://docs.vagrantup.com.
+
+  # Every Vagrant development environment requires a box. You can search for
+  # boxes at https://vagrantcloud.com/search.
+  config.vm.box = "ubuntu/bionic"
+
+  # Disable automatic box update checking. If you disable this, then
+  # boxes will only be checked for updates when the user runs
+  # `vagrant box outdated`. This is not recommended.
+  # config.vm.box_check_update = false
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # NOTE: This will enable public access to the opened port
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine and only allow access
+  # via 127.0.0.1 to disable public access
+  # config.vm.network "forwarded_port", guest: 80, host: 8080, host_ip: "127.0.0.1"
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+  #
+  # View the documentation for the provider you are using for more
+  # information on available options.
+
+  # Enable provisioning with a shell script. Additional provisioners such as
+  # Puppet, Chef, Ansible, Salt, and Docker are also available. Please see the
+  # documentation for more information about their specific syntax and use.
+  # config.vm.provision "shell", inline: <<-SHELL
+  #   apt-get update
+  #   apt-get install -y apache2
+  # SHELL
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,10 @@ Vagrant.configure("2") do |config|
   # to switch to a different config.vm.box later.
   config.vm.boot_timeout = 600
 
+  # Keep the VM's Guest Additions' version in sync with the VirtualBox host.
+  # Might require a `vagrant reload` after the first build.
+  config.vagrant.plugins = ["vagrant-vbguest"]
+
   config.vm.provider "virtualbox" do |vb|
     # This requires `brew cask install virtualbox-extension-pack` for USB3
     vb.customize ["modifyvm", :id, "--usbxhci", "on"]


### PR DESCRIPTION
My primary development machine is a mac, so I can't use the linux-specific instructions. I was following a lot of tricks from these posts:

https://dev.to/kojikanao/coral-edgetpu-usb-with-virtualbox-57e1
https://sonnguyen.ws/connect-usb-from-virtual-machine-using-vagrant-and-virtualbox/

Hopefully this makes life easier for everyone.

I was using this to test that my setup steps were reproducible:
```
vagrant destroy --force && vagrant up && vagrant reload && vagrant ssh
...
cd ~/project-posenet && python3 simple_pose.py
```