### PR TITLE
Fixes Keypoint.__repr__ formatting issue

### DIFF
--- a/pose_engine.py
+++ b/pose_engine.py
@@ -54,7 +54,7 @@ class Keypoint:
         self.score = score
 
     def __repr__(self):
-        return 'Keypoint(<{}>, {}, {})'.format(KEYPOINTS[self.k], self.yx, self.score)
+        return 'Keypoint(<{}>, {}, {})'.format(self.k, self.yx, self.score)
 
 
 class Pose:


### PR DESCRIPTION
Since `k` is already a `str` name for a keypoint, we don't need to do `KEYPOINTS[self.k]`. Otherwise it'll throw an error.